### PR TITLE
Increased compatibility with protected areas.

### DIFF
--- a/robot_ops.lua
+++ b/robot_ops.lua
@@ -192,12 +192,8 @@ function utils.robot_move (robot_pos, side)
 	if not pos then
 		return false
 	end
-
-	local in_owned_area = not minetest.is_protected(pos, meta:get_string("owner"))
-	local in_protected_area = minetest.is_protected (pos, "")
-	local denied = not in_owned_area and in_protected_area
 	
-	if denied then
+	if minetest.is_protected (pos, meta:get_string("owner")) then
 		return false
 	end
 
@@ -342,11 +338,8 @@ function utils.robot_dig (robot_pos, side)
 
 	local nodedef = minetest.registered_nodes[node.name]
 
-	local in_owned_area = not minetest.is_protected (pos, meta:get_string("owner"))
-	local in_protected_area = minetest.is_protected (pos, "")
-	local denied = not in_owned_area and in_protected_area
-
-	if not nodedef or not nodedef.diggable or denied or
+	if not nodedef or not nodedef.diggable or 
+    minetest.is_protected (pos, meta:get_string("owner")) or
 		minetest.get_item_group (node.name, "unbreakable") > 0 then
 
 		return nil
@@ -464,11 +457,7 @@ function utils.robot_place (robot_pos, side, nodename)
 		end
 	end
 
-	local in_owned_area = not minetest.is_protected (place_pos, meta:get_string("owner"))
-	local in_protected_area = minetest.is_protected (place_pos, "")
-	local denied = not in_owned_area and in_protected_area
-
-	if denied then
+	if minetest.is_protected (place_pos, meta:get_string("owner")) then
 		return false
 	end
 
@@ -495,7 +484,7 @@ function utils.robot_place (robot_pos, side, nodename)
 		pointed_thing.above = place_pos
 	end
 
-	if utils.settings.use_mod_on_place and not in_protected_area then
+	if utils.settings.use_mod_on_place and not minetest.is_protected (place_pos, "") then
 		if def and def.on_place then
 			local result, leftover = pcall (def.on_place, stack, nil, pointed_thing)
 
@@ -696,12 +685,8 @@ function utils.robot_put (robot_pos, side, item)
 	if not pos then
 		return false
 	end
-
-	local in_owned_area = not minetest.is_protected(pos, meta:get_string("owner"))
-	local in_protected_area = minetest.is_protected (pos, "")
-	local denied = not in_owned_area and in_protected_area
 	
-	if denied then
+	if minetest.is_protected (pos, meta:get_string("owner")) then
 		return false
 	end
 
@@ -794,12 +779,8 @@ function utils.robot_pull (robot_pos, side, item)
 	if not pos then
 		return false
 	end
-
-	local in_owned_area = not minetest.is_protected(pos, meta:get_string("owner"))
-	local in_protected_area = minetest.is_protected (pos, "")
-	local denied = not in_owned_area and in_protected_area
 	
-	if denied then
+	if minetest.is_protected (pos, meta:get_string("owner")) then
 		return false
 	end
 
@@ -893,12 +874,8 @@ function utils.robot_put_stack (robot_pos, side, item)
 	if not pos then
 		return false
 	end
-
-	local in_owned_area = not minetest.is_protected (pos, meta:get_string("owner"))
-	local in_protected_area = minetest.is_protected (pos, "")
-	local denied = not in_owned_area and in_protected_area
 	
-	if denied then
+	if minetest.is_protected (pos, meta:get_string("owner")) then
 		return false
 	end
 
@@ -976,12 +953,8 @@ function utils.robot_pull_stack (robot_pos, side, item)
 	if not pos then
 		return false
 	end
-
-	local in_owned_area = not minetest.is_protected (pos, meta:get_string("owner"))
-	local in_protected_area = minetest.is_protected (pos, "")
-	local denied = not in_owned_area and in_protected_area
 	
-	if denied then
+	if minetest.is_protected (pos, meta:get_string("owner")) then
 		return false
 	end
 

--- a/robot_ops.lua
+++ b/robot_ops.lua
@@ -185,7 +185,7 @@ function utils.robot_move (robot_pos, side)
 	local meta = minetest.get_meta (robot_pos)
 	local cur_node = minetest.get_node_or_nil (robot_pos)
 	if not meta or not cur_node then
-		return nil
+		return false
 	end
 
 	local pos = get_robot_side (robot_pos, cur_node.param2, side)

--- a/robot_ops.lua
+++ b/robot_ops.lua
@@ -339,7 +339,7 @@ function utils.robot_dig (robot_pos, side)
 	local nodedef = minetest.registered_nodes[node.name]
 
 	if not nodedef or not nodedef.diggable or 
-    minetest.is_protected (pos, meta:get_string("owner")) or
+		minetest.is_protected (pos, meta:get_string("owner")) or
 		minetest.get_item_group (node.name, "unbreakable") > 0 then
 
 		return nil


### PR DESCRIPTION
Robots can no longer move into protected areas or interact with chests in protected areas unless the owner of the robot is the owner of the protected area.

Robots can now place and dig nodes inside a protected area if the owner of the robot is also the owner of the protected area.